### PR TITLE
Add biomedical RAG agent demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,41 @@ placeholder for further customization.
 
 `cv_summary.txt` contains the current summary. Edit it manually before running
 the agent if you want to start from a different summary.
+
+## Biomedical RAG Agent
+
+This repository also includes a simple biomedical literature search and RAG-based question answering demo located in the `biomedrag` package.
+
+### Installation
+
+Install required packages (FAISS, scikit-learn and Streamlit):
+
+```bash
+pip install faiss-cpu scikit-learn streamlit requests
+```
+
+### CLI Usage
+
+Run an example query from the command line:
+
+```bash
+python -m biomedrag.cli "What is the role of p53 in cancer?"
+```
+
+### Streamlit Demo
+
+To launch the web demo:
+
+```bash
+streamlit run biomedrag/gui.py
+```
+
+### Evaluation
+
+An example evaluation script is provided:
+
+```bash
+python -m biomedrag.evaluator sample_questions.json
+```
+
+Note that network access may be required to fetch PubMed articles.

--- a/biomedrag/__init__.py
+++ b/biomedrag/__init__.py
@@ -1,0 +1,17 @@
+"""Biomedical RAG QA toolkit."""
+
+from .query_processor import QueryProcessor
+from .retrieval import LiteratureRetriever
+from .embedder import Embedder
+from .vector_store import VectorStore
+from .rag_generator import RAGAnswerGenerator
+from .feedback_handler import FeedbackHandler
+
+__all__ = [
+    "QueryProcessor",
+    "LiteratureRetriever",
+    "Embedder",
+    "VectorStore",
+    "RAGAnswerGenerator",
+    "FeedbackHandler",
+]

--- a/biomedrag/cli.py
+++ b/biomedrag/cli.py
@@ -1,0 +1,31 @@
+import argparse
+from .query_processor import QueryProcessor
+from .retrieval import LiteratureRetriever
+from .embedder import Embedder
+from .vector_store import VectorStore
+from .rag_generator import RAGAnswerGenerator
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Biomedical RAG CLI")
+    parser.add_argument("question", help="Question to answer")
+    args = parser.parse_args()
+
+    qp = QueryProcessor()
+    retriever = LiteratureRetriever()
+    embedder = Embedder()
+    store = VectorStore()
+    generator = RAGAnswerGenerator(embedder, store)
+
+    q = qp.process(args.question)
+    try:
+        docs = retriever.search(q)
+    except Exception as exc:
+        print(f"Retrieval failed: {exc}")
+        docs = []
+    ans = generator.generate(q, docs)
+    print(ans)
+
+
+if __name__ == "__main__":
+    main()

--- a/biomedrag/embedder.py
+++ b/biomedrag/embedder.py
@@ -1,0 +1,15 @@
+from typing import List
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+
+class Embedder:
+    """TF-IDF based text embedder."""
+
+    def __init__(self):
+        self.vectorizer = TfidfVectorizer(stop_words="english")
+
+    def fit_transform(self, texts: List[str]):
+        return self.vectorizer.fit_transform(texts).toarray()
+
+    def transform(self, texts: List[str]):
+        return self.vectorizer.transform(texts).toarray()

--- a/biomedrag/evaluator.py
+++ b/biomedrag/evaluator.py
@@ -1,0 +1,40 @@
+import json
+from .query_processor import QueryProcessor
+from .retrieval import LiteratureRetriever
+from .embedder import Embedder
+from .vector_store import VectorStore
+from .rag_generator import RAGAnswerGenerator
+
+
+class Evaluator:
+    """Run sample questions through the pipeline."""
+
+    def __init__(self, questions_file: str):
+        with open(questions_file) as f:
+            self.questions = json.load(f)
+        self.qp = QueryProcessor()
+        self.retriever = LiteratureRetriever()
+        self.embedder = Embedder()
+        self.store = VectorStore()
+        self.generator = RAGAnswerGenerator(self.embedder, self.store)
+
+    def evaluate(self, limit: int = 1):
+        results = []
+        for q in self.questions[:limit]:
+            processed = self.qp.process(q)
+            try:
+                docs = self.retriever.search(processed)
+            except Exception as exc:
+                docs = []
+                print(f"Retrieval failed for '{q}': {exc}")
+            answer = self.generator.generate(processed, docs)
+            results.append({"question": q, "answer": answer})
+        return results
+
+
+if __name__ == "__main__":
+    import sys
+    eval_file = sys.argv[1] if len(sys.argv) > 1 else "sample_questions.json"
+    ev = Evaluator(eval_file)
+    for res in ev.evaluate(limit=3):
+        print(f"Q: {res['question']}\nA: {res['answer']}\n")

--- a/biomedrag/feedback_handler.py
+++ b/biomedrag/feedback_handler.py
@@ -1,0 +1,14 @@
+from typing import List
+
+
+class FeedbackHandler:
+    """Stores user feedback to refine answers."""
+
+    def __init__(self):
+        self.messages: List[str] = []
+
+    def add(self, feedback: str):
+        self.messages.append(feedback)
+
+    def latest(self):
+        return self.messages[-1] if self.messages else None

--- a/biomedrag/gui.py
+++ b/biomedrag/gui.py
@@ -1,0 +1,45 @@
+import streamlit as st
+from .query_processor import QueryProcessor
+from .retrieval import LiteratureRetriever
+from .embedder import Embedder
+from .vector_store import VectorStore
+from .rag_generator import RAGAnswerGenerator
+from .feedback_handler import FeedbackHandler
+
+
+def main():
+    st.title("Biomedical RAG QA")
+    qp = QueryProcessor()
+    retriever = LiteratureRetriever()
+    embedder = Embedder()
+    store = VectorStore()
+    generator = RAGAnswerGenerator(embedder, store)
+    feedback = FeedbackHandler()
+
+    if "history" not in st.session_state:
+        st.session_state.history = []
+
+    query = st.text_input("Ask a biomedical question:")
+    if st.button("Submit") and query:
+        processed = qp.process(query)
+        try:
+            docs = retriever.search(processed, retmax=5)
+        except Exception as exc:
+            st.error(f"Retrieval failed: {exc}")
+            docs = []
+        answer = generator.generate(processed, docs)
+        st.session_state.history.append({"query": query, "answer": answer})
+
+    for entry in st.session_state.history:
+        st.markdown(f"**Q:** {entry['query']}")
+        st.markdown(f"**A:** {entry['answer']}")
+        st.markdown("---")
+
+    fb = st.text_input("Feedback", key="feedback")
+    if st.button("Send Feedback") and fb:
+        feedback.add(fb)
+        st.success("Feedback stored")
+
+
+if __name__ == "__main__":
+    main()

--- a/biomedrag/query_processor.py
+++ b/biomedrag/query_processor.py
@@ -1,0 +1,7 @@
+class QueryProcessor:
+    """Simple processor to clean user queries."""
+
+    def process(self, query: str) -> str:
+        if not query:
+            return ""
+        return query.strip()

--- a/biomedrag/rag_generator.py
+++ b/biomedrag/rag_generator.py
@@ -1,0 +1,47 @@
+from typing import List, Dict
+import os
+
+try:
+    import openai
+except ImportError:  # pragma: no cover
+    openai = None
+
+
+class RAGAnswerGenerator:
+    """Retrieve-then-answer generation pipeline."""
+
+    def __init__(self, embedder, vector_store):
+        self.embedder = embedder
+        self.vector_store = vector_store
+
+    def generate(self, query: str, documents: List[Dict[str, str]], top_k: int = 3) -> str:
+        texts = [doc.get("abstract") or doc.get("title", "") for doc in documents]
+        if texts:
+            embeddings = self.embedder.fit_transform(texts)
+            self.vector_store.build(embeddings, documents)
+            q_vec = self.embedder.transform([query])
+            top_docs, _ = self.vector_store.search(q_vec, k=top_k)
+        else:
+            top_docs = []
+        context = "\n\n".join(
+            f"PMID:{d['pmid']} Title:{d['title']} Abstract:{d['abstract']}" for d in top_docs
+        )
+        prompt = (
+            "Answer the biomedical question using the documents provided. "
+            "Cite PMIDs in your answer.\n" + context + f"\nQuestion: {query}\nAnswer:"
+        )
+        if openai and os.getenv("OPENAI_API_KEY"):
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return resp.choices[0].message.content.strip()
+        # Fallback: simple concatenation
+        if top_docs:
+            snippets = "\n\n".join(d["abstract"] for d in top_docs)
+            answer = f"Based on the following articles:\n{snippets}\n\nQuestion: {query}\n"
+            answer += "Please refer to the cited PMIDs for details."
+        else:
+            answer = "No relevant documents were retrieved to answer the question."
+            answer += f"\nQuestion: {query}"
+        return answer

--- a/biomedrag/retrieval.py
+++ b/biomedrag/retrieval.py
@@ -1,0 +1,42 @@
+import requests
+import xml.etree.ElementTree as ET
+from typing import List, Dict, Optional
+
+
+class LiteratureRetriever:
+    """Fetches articles from PubMed using E-utilities."""
+
+    def __init__(self, email: Optional[str] = None):
+        self.esearch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
+        self.efetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+        self.email = email
+
+    def search(self, query: str, retmax: int = 5) -> List[Dict[str, str]]:
+        """Return a list of articles with pmid, title, and abstract."""
+        params = {"db": "pubmed", "term": query, "retmode": "json", "retmax": retmax}
+        if self.email:
+            params["email"] = self.email
+        resp = requests.get(self.esearch_url, params=params, timeout=10)
+        resp.raise_for_status()
+        ids = resp.json().get("esearchresult", {}).get("idlist", [])
+        if not ids:
+            return []
+        fetch_params = {
+            "db": "pubmed",
+            "id": ",".join(ids),
+            "retmode": "xml",
+        }
+        if self.email:
+            fetch_params["email"] = self.email
+        resp = requests.get(self.efetch_url, params=fetch_params, timeout=10)
+        resp.raise_for_status()
+        root = ET.fromstring(resp.text)
+        records = []
+        for article in root.findall(".//PubmedArticle"):
+            pmid = article.findtext(".//PMID")
+            title = article.findtext(".//ArticleTitle") or ""
+            abstract = " ".join(
+                t.text or "" for t in article.findall(".//AbstractText")
+            )
+            records.append({"pmid": pmid, "title": title, "abstract": abstract})
+        return records

--- a/biomedrag/vector_store.py
+++ b/biomedrag/vector_store.py
@@ -1,0 +1,24 @@
+from typing import List, Any
+import faiss
+import numpy as np
+
+
+class VectorStore:
+    """FAISS-based vector store."""
+
+    def __init__(self):
+        self.index = None
+        self.meta: List[Any] = []
+
+    def build(self, embeddings: np.ndarray, metadata: List[Any]):
+        dim = embeddings.shape[1]
+        self.index = faiss.IndexFlatL2(dim)
+        self.index.add(embeddings.astype('float32'))
+        self.meta = metadata
+
+    def search(self, vector: np.ndarray, k: int = 3):
+        if self.index is None:
+            raise ValueError("Index not built")
+        distances, idx = self.index.search(vector.astype('float32'), k)
+        results = [self.meta[i] for i in idx[0]]
+        return results, distances[0]

--- a/sample_questions.json
+++ b/sample_questions.json
@@ -1,0 +1,5 @@
+[
+    "What are the latest treatments for type 2 diabetes?",
+    "How does CRISPR gene editing work?",
+    "What is the role of p53 in cancer?"
+]


### PR DESCRIPTION
## Summary
- add a minimal biomedical RAG question answering toolkit under `biomedrag`
- provide modules for querying PubMed, embedding text, FAISS storage and answer generation
- include a Streamlit GUI, CLI entry point and evaluation script
- update README with instructions
- add a few sample questions for evaluation

## Testing
- `python -m py_compile biomedrag/*.py`
- `python -m biomedrag.evaluator sample_questions.json` *(fails to retrieve papers due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6871508c87f8832e92a74b77d9f9e9e0